### PR TITLE
Update addon-developer-support and use Services global variable

### DIFF
--- a/chrome/content/api/NotifyTools/schema.json
+++ b/chrome/content/api/NotifyTools/schema.json
@@ -1,6 +1,6 @@
 [
   {
-    "namespace": "NotifyTools",    
+    "namespace": "NotifyTools",
     "events": [
       {
         "name": "onNotifyBackground",

--- a/chrome/content/api/Utilities/implementation.js
+++ b/chrome/content/api/Utilities/implementation.js
@@ -1,7 +1,6 @@
 /* eslint-disable object-shorthand */
 
 var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm"),
-    { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm"),
     win = Services.wm.getMostRecentWindow("mail:3pane");
 
 console.log("quickFilters - implementation utilities");

--- a/chrome/content/api/WindowListener/schema.json
+++ b/chrome/content/api/WindowListener/schema.json
@@ -34,7 +34,7 @@
             "type": "array",
             "items": {
               "type": "array",
-              "items" : {
+              "items": {
                 "type": "string"
               }
             },

--- a/chrome/content/qFilters-filterEditor.js
+++ b/chrome/content/qFilters-filterEditor.js
@@ -10,8 +10,6 @@ For details, please refer to license.txt in the root folder of this extension
 END LICENSE BLOCK 
 */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 // highlight removable filter conditions (duplicates)
 // window.onload = function()
 {

--- a/chrome/content/qFilters-list.js
+++ b/chrome/content/qFilters-list.js
@@ -10,8 +10,6 @@ For details, please refer to license.txt in the root folder of this extension
 END LICENSE BLOCK 
 */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 // note: in QuickFolder_s, this object is simply called "Filter"!
 quickFilters.List = {
   eventsAreHooked: false ,

--- a/chrome/content/qFilters-options.js
+++ b/chrome/content/qFilters-options.js
@@ -10,7 +10,6 @@ For details, please refer to license.txt in the root folder of this extension
 END LICENSE BLOCK 
 */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
 
 quickFilters.Options = {

--- a/chrome/content/qFilters-preferences.js
+++ b/chrome/content/qFilters-preferences.js
@@ -11,9 +11,6 @@ END LICENSE BLOCK
 */
 
 
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
-
-
 quickFilters.Preferences = {
   Prefix: "extensions.quickfilters.",
 	service: Services.prefs,

--- a/chrome/content/qFilters-register-dlg.js
+++ b/chrome/content/qFilters-register-dlg.js
@@ -12,8 +12,6 @@
 
 /* [mx-l10n] This module handles front-end code for the licensing dialog  */
 
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
-
 // removed UI function from quickFilters.Licenser
 var Register = {
   l10n: function() {

--- a/chrome/content/qFilters-utils.js
+++ b/chrome/content/qFilters-utils.js
@@ -11,7 +11,6 @@ END LICENSE BLOCK
 
 // moved import code to bottom for app version detection...
 
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
 var { MailServices } = ChromeUtils.import("resource:///modules/MailServices.jsm");
 
 var QuickFilters_TabURIregexp = {

--- a/chrome/content/qFilters-worker.js
+++ b/chrome/content/qFilters-worker.js
@@ -9,8 +9,6 @@ For details, please refer to license.txt in the root folder of this extension
 END LICENSE BLOCK 
 */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 // note: in QuickFolder_s, this object is simply called "Filter"!
 quickFilters.Worker = {
   bundle: null,

--- a/chrome/content/quickFilters.js
+++ b/chrome/content/quickFilters.js
@@ -580,7 +580,6 @@ END LICENSE BLOCK
     
    */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 var {MailServices} = ChromeUtils.import("resource:///modules/MailServices.jsm");
     
 var quickFilters = {

--- a/chrome/content/scripts/notifyTools.js
+++ b/chrome/content/scripts/notifyTools.js
@@ -9,7 +9,17 @@ var ADDON_ID = "quickFilters@" + "axelg" + "." + "com";
  * For usage descriptions, please check:
  * https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools
  *
- * Version: 1.3
+ * Version 1.6
+ * - adjusted to Thunderbird Supernova (Services is now in globalThis)
+ *
+ * Version 1.5
+ * - deprecate enable(), disable() and registerListener()
+ * - add setAddOnId()
+ *
+ * Version 1.4
+ * - auto enable/disable
+ *
+ * Version 1.3
  * - registered listeners for notifyExperiment can return a value
  * - remove WindowListener from name of observer
  *
@@ -20,21 +30,30 @@ var ADDON_ID = "quickFilters@" + "axelg" + "." + "com";
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 
 var notifyTools = {
   registeredCallbacks: {},
   registeredCallbacksNextId: 1,
+  addOnId: ADDON_ID,
+
+  setAddOnId: function (addOnId) {
+    this.addOnId = addOnId;
+  },
 
   onNotifyExperimentObserver: {
     observe: async function (aSubject, aTopic, aData) {
-      if (ADDON_ID == "") {
+      if (notifyTools.addOnId == "") {
         throw new Error("notifyTools: ADDON_ID is empty!");
       }
-      if (aData != ADDON_ID) {
+      if (aData != notifyTools.addOnId) {
         return;
       }
       let payload = aSubject.wrappedJSObject;
+
+      // Make sure payload has a resolve function, which we use to resolve the
+      // observer notification.
       if (payload.resolve) {
         let observerTrackerPromises = [];
         // Push listener into promise array, so they can run in parallel
@@ -62,17 +81,26 @@ var notifyTools = {
           payload.resolve(results[0]);
         }
       } else {
-        // Just call the listener.
+        // Older version of NotifyTools, which is not sending a resolve function, deprecated.
+        console.log("Please update the notifyTools API to at least v1.5");
         for (let registeredCallback of Object.values(
           notifyTools.registeredCallbacks
         )) {
           registeredCallback(payload.data);
         }
-      }    
+      }
     },
   },
 
-  registerListener: function (listener) {
+  addListener: function (listener) {
+    if (Object.values(this.registeredCallbacks).length == 0) {
+      Services.obs.addObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver",
+        false
+      );
+    }
+
     let id = this.registeredCallbacksNextId++;
     this.registeredCallbacks[id] = listener;
     return id;
@@ -80,50 +108,61 @@ var notifyTools = {
 
   removeListener: function (id) {
     delete this.registeredCallbacks[id];
+    if (Object.values(this.registeredCallbacks).length == 0) {
+      Services.obs.removeObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver"
+      );
+    }
+  },
+
+  removeAllListeners: function () {
+    if (Object.values(this.registeredCallbacks).length != 0) {
+      Services.obs.removeObserver(
+        this.onNotifyExperimentObserver,
+        "NotifyExperimentObserver"
+      );
+    }
+    this.registeredCallbacks = {};
   },
 
   notifyBackground: function (data) {
-    if (ADDON_ID == "") {
+    if (this.addOnId == "") {
       throw new Error("notifyTools: ADDON_ID is empty!");
     }
     return new Promise((resolve) => {
       Services.obs.notifyObservers(
         { data, resolve },
         "NotifyBackgroundObserver",
-        ADDON_ID
+        this.addOnId
       );
     });
   },
-  
-  enable: function() {
-    Services.obs.addObserver(
-      this.onNotifyExperimentObserver,
-      "NotifyExperimentObserver",
-      false
-    );
+
+
+  // Deprecated.
+
+  enable: function () {
+    console.log("Manually calling notifyTools.enable() is no longer needed.");
   },
 
-  disable: function() {
-    Services.obs.removeObserver(
-      this.onNotifyExperimentObserver,
-      "NotifyExperimentObserver"
-    );
+  disable: function () {
+    console.log("notifyTools.disable() has been deprecated, use notifyTools.removeAllListeners() instead.");
+    this.removeAllListeners();
   },
+
+  registerListener: function (listener) {
+    console.log("notifyTools.registerListener() has been deprecated, use notifyTools.addListener() instead.");
+    this.addListener(listener);
+  },
+
 };
 
-
-if (window) {
+if (typeof window != "undefined" && window) {
   window.addEventListener(
-    "load",
+    "unload",
     function (event) {
-      notifyTools.enable();
-      window.addEventListener(
-        "unload",
-        function (event) {
-          notifyTools.disable();
-        },
-        false
-      );
+      notifyTools.removeAllListeners();
     },
     false
   );

--- a/chrome/content/scripts/qFi-filterEditor.js
+++ b/chrome/content/scripts/qFi-filterEditor.js
@@ -1,5 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 Services.scriptloader.loadSubScript("chrome://quickfilters/content/quickFilters.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfilters/content/qFilters-utils.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfilters/content/qFilters-preferences.js", window, "UTF-8");

--- a/chrome/content/scripts/qFi-filterlist.js
+++ b/chrome/content/scripts/qFi-filterlist.js
@@ -1,5 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 async function setAssistantButton(e) {
   window.quickFilters.List.setAssistantButton(e.detail.active);
 }

--- a/chrome/content/scripts/qFi-messenger.js
+++ b/chrome/content/scripts/qFi-messenger.js
@@ -1,5 +1,3 @@
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
 Services.scriptloader.loadSubScript("chrome://quickfilters/content/quickFilters.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfilters/content/qFilters-preferences.js", window, "UTF-8");
 Services.scriptloader.loadSubScript("chrome://quickfilters/content/qFilters-utils.js", window, "UTF-8");

--- a/scripts/Licenser.mjs.js
+++ b/scripts/Licenser.mjs.js
@@ -169,7 +169,6 @@ export class Licenser {
 	async graceDate() {
 		let graceDate = "", isResetDate = false;
 		try {
-      var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 			graceDate = Services.prefs.getStringPref("license.gracePeriodDate");
 		}
 		catch(ex) { 


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 .
Services global variable is in all system globals from version 104
https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 ,
and those code doesn't have to import Services.jsm if the
strict_min_version is 112.