### PR TITLE
#385 - force unsafe URL loading to enable TB155 compatibility

### DIFF
--- a/chrome/content/api/WindowListener/implementation.js
+++ b/chrome/content/api/WindowListener/implementation.js
@@ -35,10 +35,24 @@ function getThunderbirdVersion() {
     minor: parseInt(parts[1]),
   }
 }
-
 var WindowListener = class extends ExtensionCommon.ExtensionAPI {
   log(msg) {
     if (this.debug) console.log("WindowListener API: " + msg);
+  }
+
+  /**
+   * Load a WindowListener-owned script from the extension package.
+   *
+   * Thunderbird 155 rejects jar: and file: URLs passed to loadSubScript() unless
+   * the caller explicitly opts in. loadSubScriptWithOptions() and the target
+   * option are available on Thunderbird 140; older versions ignore the new
+   * allowUnsafeURL option.
+   */
+  loadSubScript(url, target) {
+    return Services.scriptloader.loadSubScriptWithOptions(url, {
+      target,
+      allowUnsafeURL: true,
+    });
   }
 
   getCards(e) {
@@ -334,7 +348,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
                 );
             }
           };
-          Services.scriptloader.loadSubScript(url, prefsObj, "UTF-8");
+          self.loadSubScript(url, prefsObj);
         },
 
         registerChromeUrl(data) {
@@ -419,7 +433,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
             startupJS.WL.messenger = self.getMessenger(self.context);
             try {
               if (self.pathToStartupScript) {
-                Services.scriptloader.loadSubScript(self.pathToStartupScript, startupJS, "UTF-8");
+                self.loadSubScript(self.pathToStartupScript, startupJS);
                 // delay startup until startup has been finished
                 self.log(
                   "Waiting for async startup() in <" + self.pathToStartupScript + "> to finish."
@@ -719,10 +733,9 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
         // Add messenger object to WLDATA object
         window[this.uniqueRandomID].WL.messenger = this.getMessenger(this.context);
         // Load script into add-on scope
-        Services.scriptloader.loadSubScript(
+        this.loadSubScript(
           this.registeredWindows[window.location.href],
-          window[this.uniqueRandomID],
-          "UTF-8"
+          window[this.uniqueRandomID]
         );
         window[this.uniqueRandomID].onLoad(isAddonActivation);
       } catch (e) {
@@ -843,7 +856,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
     shutdownJS.extension = this.extension;
     try {
       if (this.pathToShutdownScript)
-        Services.scriptloader.loadSubScript(this.pathToShutdownScript, shutdownJS, "UTF-8");
+        this.loadSubScript(this.pathToShutdownScript, shutdownJS);
     } catch (e) {
       Components.utils.reportError(e);
     }

--- a/chrome/content/qFilters-utils.js
+++ b/chrome/content/qFilters-utils.js
@@ -307,10 +307,12 @@ quickFilters.Util = {
   },
 
   localize: function (window, buttons = null) {
-    Services.scriptloader.loadSubScript(
+    Services.scriptloader.loadSubScriptWithOptions(
       quickFilters.Util.extension.rootURI.resolve("chrome/content/i18n.js"),
-      window,
-      "UTF-8"
+      {
+        target: window,
+        allowUnsafeURL: true,
+      }
     );
     window.i18n.updateDocument({ extension: quickFilters.Util.extension });
     if (buttons) {
@@ -959,6 +961,13 @@ quickFilters.Util = {
 
   logDebug: function (...args) {
     let qF = quickFilters ? quickFilters : this.mainInstance;
+    // During startup, a WindowListener-injected window can exist before its
+    // qFilters-preferences.js subscript has finished loading. We cannot yet
+    // consult the debug preference, so preserve the diagnostic unconditionally.
+    if (!qF?.Preferences) {
+      this.logToConsole("quickFilters [preferences not initialized]", ...args);
+      return;
+    }
     let p = qF.Preferences.isDebug;
     if (!p) {
       return;
@@ -3436,8 +3445,10 @@ var { ExtensionParent } = ChromeUtils.importESModule(
   "resource://gre/modules/ExtensionParent.sys.mjs"
 );
 quickFilters.Util.extension = ExtensionParent.GlobalManager.getExtension("quickFilters@axelg.com");
-Services.scriptloader.loadSubScript(
+Services.scriptloader.loadSubScriptWithOptions(
   quickFilters.Util.extension.rootURI.resolve("chrome/content/scripts/notifyTools.js"),
-  quickFilters.Util,
-  "UTF-8"
+  {
+    target: quickFilters.Util,
+    allowUnsafeURL: true,
+  }
 );


### PR DESCRIPTION
using `loadSubScriptWithOptions() `to force unsafe URL. This is to fix the Add-on not loading anymore in Thunderbird 155 Daily because untrusted URI issues caused by [Bug 1974213](https://bugzilla.mozilla.org/show_bug.cgi?id=1974213) "Don't allow file: and jar: schemes in `Services.scriptloader.loadSubScript`"